### PR TITLE
feat: Allow linking with `jslink`

### DIFF
--- a/tests/test_with_coordination.py
+++ b/tests/test_with_coordination.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 from inline_snapshot import snapshot
@@ -163,3 +164,38 @@ def test_add_widgets_to_existing_coordination(coordination_path: pathlib.Path):
     assert slider1.value == 0.6
     assert slider2.value == 0.8
     assert slider3.value == 0.8
+
+
+def test_jslink_for_type():
+    slider1 = FloatSlider()
+    slider2 = FloatSlider()
+
+    with patch("ipywidgets.jslink") as jslink:
+        with Coordination() as c:
+            with c.type("sliderValue", jslink=True) as t:
+                with t.scope("A", 10) as s:
+                    s.view(slider1, alias="value")
+                    s.view(slider2, alias="value")
+
+        assert jslink.call_count == 1
+
+
+def test_jslink_for_scope():
+    slider1 = FloatSlider()
+    slider2 = FloatSlider()
+
+    slider3 = FloatSlider()
+    slider4 = FloatSlider()
+
+    with patch("ipywidgets.jslink") as jslink:
+        with Coordination() as c:
+            with c.type("sliderValue") as t:
+                with t.scope("A", 10, jslink=True) as s:
+                    s.view(slider1, alias="value")
+                    s.view(slider2, alias="value")
+
+                with t.scope("B", 4.0) as s:
+                    s.view(slider3, alias="value")
+                    s.view(slider4, alias="value")
+
+        assert jslink.call_count == 1


### PR DESCRIPTION
Closes #4 

Whether to use `ipywidgets.jslink` to link scopes (rather than `ipywidgets.link`). Widgets are linked in the front end, and therefore do not require a server roundtrip for updtes. This would be a sensible default, but not all fields can safely be jslinked so it's opt-in.

```py
slider1 = FloatSlider()
slider2 = FloatSlider()

slider3 = FloatSlider()
slider4 = FloatSlider()

# link all sliderValue coordination scopes
with Coordination() as c:
    with c.type("sliderValue", jslink=True) as t:
        with t.scope("A", 10) as s:
            s.view(slider1, alias="value")
            s.view(slider2, alias="value")
        with t.scope("B", 20) as s:
            s.view(slider3, alias="value")
            s.view(slider4, alias="value")


# jslink just the sliderValue scope A, scope B requires a server roundtrip
with Coordination() as c:
    with c.type("sliderValue") as t:
        with t.scope("A", 10, jslink=True) as s:
            s.view(slider1, alias="value")
            s.view(slider2, alias="value")

        with t.scope("B", 20) as s: # jslink=False is the default
            s.view(slider3, alias="value")
            s.view(slider4, alias="value")
```

Important to note: if all views are `jslink`ed, the configured widget view can be exported to standalone HTML without a Python backend. This makes it possible to configure a set of widgets/views from Python for an entirely client-side app. Just using Python for coordination.

For an existing config, fields to jslink are specified with `jslinks`:

```py
with Coordination("config.json") as c:
  c.use_widget(slider1, aliases={"value": "sliderValue"}, jslinks={"value"})
  c.use_widget(slider2, aliases={"value": "sliderValue"}, jslinks={"value"})
```
